### PR TITLE
Make headings compatible with outline-minor-mode

### DIFF
--- a/treepy.el
+++ b/treepy.el
@@ -162,7 +162,7 @@ Execute BODY in this context."
                          vars)))
     `(let* (,@lex-ctx) ,@body)))
 
-;; Construction
+;;;; Construction
 
 (defun treepy-zipper (branchp children make-node root)
   "Create a new zipper structure.
@@ -192,7 +192,7 @@ ROOT is the root node."
         (children (lambda (cs) (seq-into cs 'list))))
     (treepy-zipper #'vectorp children make-node root)))
 
-;; Context
+;;;; Context
 
 (defun treepy-node (loc)
   "Return the node at LOC."
@@ -226,7 +226,7 @@ with them.  The LOC is only used to supply the constructor."
   "Return a list of the right siblings of this LOC."
   (treepy--context loc ':r))
 
-;; Navigation
+;;;; Navigation
 
 (defun treepy-down (loc)
   "Return the loc of the leftmost child of the node at this LOC.
@@ -325,7 +325,7 @@ If LOC is already the leftmost sibiling, return self."
     (setq loc (treepy-down loc)))
   loc)
 
-;; Modification
+;;;; Modification
 
 (defun treepy-insert-left (loc item)
   "Insert as the left sibiling of this LOC'S node the ITEM.
@@ -398,7 +398,7 @@ walk."
                (and ppath (treepy--context-assoc context ':changed? t)))
          (treepy--meta loc))))))
 
-;; Enumeration
+;;;; Enumeration
 
 (defun treepy--preorder-next (loc)
   "Move to the next LOC in the hierarchy, depth-first in preorder.


### PR DESCRIPTION
The headings of subsections begin with one *additional* semicolon
compared to the headings of top-level sections.  Following this
convention makes the headings compatible with `outline-minor-mode`.