### PR TITLE
Non nil ending lists

### DIFF
--- a/test/treepy.el-walker-test.el
+++ b/test/treepy.el-walker-test.el
@@ -5,7 +5,7 @@
 ;; Description: Generic Tree Traversal Tools
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
 ;; 

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -5,7 +5,7 @@
 ;; Description: Generic Tree Traversal Tools
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25"))
 ;; URL: https://github.com/volrath/treepy.el
 ;; 

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -67,6 +67,7 @@
     (should (equal list-tree (treepy-root lz)))
     (should (equal list-tree (treepy-node lz)))))
 
+
 ;;; List Zipper
 
 (ert-deftest treepy-navigation ()
@@ -111,7 +112,29 @@
            (:r . (4 ((:a 5) (:b ((:c 6) (:d 7))))))))
     (-> lz
         treepy-up)
-    `(,list-tree . ,nil)))
+    `(,list-tree . ,nil))
+
+  ;; Treepy handles non-nil cdr ending lists gracefully.
+  (assert-traversing-with-persistent-zipper [lz (treepy-list-zip '(a b . c))]
+    (-> lz
+        treepy-next
+        treepy-next
+        treepy-next)
+    '(c . ((:l . (b a))
+           (:pnodes . ((a b . c)))
+           (:ppath . nil)
+           (:r . nil)))
+    (-> lz
+        treepy-prev
+        treepy-next)
+    '(c . ((:l . (b a))
+           (:pnodes . ((a b . c)))
+           (:ppath . nil)
+           (:r . nil)))
+    (-> lz
+        treepy-next)
+    '((a b . c) . :end)))
+
 
 ;;; Vector Zipper
 
@@ -270,6 +293,7 @@
                  '(1 2 4 5 3)))
   (should (equal (traverse-tree :postorder)
                  '(4 5 2 3 1))))
+
 
 ;;; Custom Zipper
 ;; Taken from Alex Miller's article: Tree visitors in Clojure
@@ -498,7 +522,7 @@ NODE is an AST node.  CHILDREN is a list of AST nodes."
   (should (equal (treepy-parseclj--traverse-tree)
                  '(:root :list defn a-test :vector x "fn documentation" :map :key x))))
 
-
 (provide 'treepy-zipper-tests)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; treepy-zipper-tests.el ends here

--- a/treepy.el
+++ b/treepy.el
@@ -270,14 +270,20 @@ Reflect any alterations to the tree."
   "Return the loc of the right sibling of the node at this LOC.
 nil if there's no more right sibilings."
   (treepy--with-loc loc (node context l r)
-    (seq-let [cr &rest rnext] r
-      (when (and context r)
-        (treepy--with-meta
-         (cons cr
-               (treepy--context-assoc context
-                                      ':l (cons node l)
-                                      ':r rnext))
-         (treepy--meta loc))))))
+    (let ((r (if (listp r)
+                 r
+               ;; If `r' is not a list (or nil), then we're dealing with a non
+               ;; nil cdr ending list.
+               (cons r nil))))
+      (seq-let [cr &rest rnext] r
+        (when (and context r)
+          (treepy--with-meta
+           (cons cr
+                 (treepy--context-assoc context
+                                        ':l (cons node l)
+                                        ':r rnext))
+           (treepy--meta loc)))))))
+
 
 (defun treepy-rightmost (loc)
   "Return the loc of the rightmost sibling of the node at this LOC.

--- a/treepy.el
+++ b/treepy.el
@@ -8,7 +8,7 @@
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Keywords: lisp, maint, tools
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
 ;; 


### PR DESCRIPTION
Closes #3

Using dotted pair notation, elisp lets you create lists that don't end in nil.  Regular lists usually look like this:

`'(rose violet buttercup)`
```
         --- ---      --- ---      --- ---
        |   |   |--> |   |   |--> |   |   |--> nil
         --- ---      --- ---      --- ---
          |            |            |
          |            |            |
           --> rose     --> violet   --> buttercup
```

But you can make them end on a 'non sequence' object, instead of a last `cons` with nil ending.  For example:

`'(rose violet . buttercup)`
```
         --- ---      --- ---
        |   |   |--> |   |   |--> buttercup
         --- ---      --- ---
          |            |
          |            |
           --> rose     --> violet
```

This case made the previous `treepy-right` implementation to throw an exception, given that it uses `seq-let` to deconstruct lists.

When `seq-let` faces an object that doesn't satisfy `sequencep` (like `'buttercup` in this example) it fails to destructure the list and throws a `(wrong-type-argument sequencep butterfly)` error.

In order to prevent this, we check that the thing we're about to deconstruct is actually a sequence, and if not, we `cons` it to nil, so that `seq-let` is able to process it.