### PR TITLE
Fix incompatibility with recent master branch of Emacs

### DIFF
--- a/treepy.el
+++ b/treepy.el
@@ -41,6 +41,7 @@
 ;;; Code:
 
 (require 'map)
+(require 'cl-lib)
 
 ;;; Walk (recursive tree traversal)
 


### PR DESCRIPTION
http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=0e4dd67aae8b10032317a29a6bd99d2d4a64c897

After above commit treepy.el isn't compatible with master branch of
Emacs.

For example byte-compiling it results in following error messages.

```
In treepy--with-loc:
treepy.el:157:35:Warning: `'node' is a malformed function
treepy.el:157:35:Warning: `'context' is a malformed function
treepy.el:160:51:Warning: `t' called as a function
treepy.el:231:1:Error: Invalid function: 'node
*** Error code 1
```

This fixes issue #5.
