### PR TITLE
Don't quote keys in cl-case

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)))

--- a/test/treepy.el-walker-test.el
+++ b/test/treepy.el-walker-test.el
@@ -1,38 +1,29 @@
-;;; treepy-walker-tests.el --- Generic tree traversal tools           -*- lexical-binding: t -*-
-;; 
-;; Filename: treepy.el-walker-test.el
-;;
-;; Description: Generic Tree Traversal Tools
+;;; treepy-walker-tests.el --- Generic tree traversal tools  -*- lexical-binding: t -*-
+
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
 ;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
-;;; Commentary: 
-;; 
-;; Generic tools for recursive and iterative tree traversal based on
-;; clojure.walk and clojure.zip respectively.
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or (at
 ;; your option) any later version.
-;; 
+;;
 ;; This program is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;; 
+;;
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
+;;; Commentary:
+
+;; Generic tools for recursive and iterative tree traversal based on
+;; clojure.walk and clojure.zip respectively.
+
 ;;; Code:
 
 (require 'ert)
@@ -137,5 +128,4 @@
                  '(:b (1 2 3 :c :b) ((:b . :c) (:c . :b))))))
 
 (provide 'treepy-walker-tests)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; treepy-walker-tests.el ends here

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -1,38 +1,29 @@
 ;;; treepy-zipper-tests.el --- Generic tree traversal tools           -*- lexical-binding: t -*-
-;; 
-;; Filename: treepy.el-zipper-test.el
-;;
-;; Description: Generic Tree Traversal Tools
+
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
 ;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25"))
 ;; URL: https://github.com/volrath/treepy.el
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
-;;; Commentary: 
-;; 
-;; Generic tools for recursive and iterative tree traversal based on
-;; clojure.walk and clojure.zip respectively.
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or (at
 ;; your option) any later version.
-;; 
+;;
 ;; This program is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;; 
+;;
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
+;;; Commentary:
+
+;; Generic tools for recursive and iterative tree traversal based on
+;; clojure.walk and clojure.zip respectively.
+
 ;;; Code:
 
 (require 'ert)
@@ -524,5 +515,4 @@ NODE is an AST node.  CHILDREN is a list of AST nodes."
 
 (provide 'treepy-zipper-tests)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; treepy-zipper-tests.el ends here

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -361,21 +361,21 @@ be (defn new-&node-type> [field-map])."
 
 (defun custom-children (node)
   (cl-case (node-type node)
-    (':root (map-elt node ':children))
-    (':compare-criteria (list (map-elt node ':left) (map-elt node ':right)))
-    (':concat (map-elt node ':args))
-    (':value (list (map-elt node ':val)))))
+    (:root (map-elt node ':children))
+    (:compare-criteria (list (map-elt node ':left) (map-elt node ':right)))
+    (:concat (map-elt node ':args))
+    (:value (list (map-elt node ':val)))))
 
 (defun custom-make-node (node children)
   (let* ((type (node-type node))
          (constructor (intern (concat "new-" (substring (symbol-name type) 1 nil)))))
     (funcall constructor
              (cl-case type
-               (':root `((:children . ,children)))
-               (':compare-criteria `((:left . ,(car children))
-                                     (:right . ,(cadr children))))
-               (':concat `((:args . ,children)))
-               (':value `((:val . ,(car children))))))))
+               (:root `((:children . ,children)))
+               (:compare-criteria `((:left . ,(car children))
+                                    (:right . ,(cadr children))))
+               (:concat `((:args . ,children)))
+               (:value `((:val . ,(car children))))))))
 
 (setq custom-zipper (treepy-zipper #'custom-branch-p #'custom-children #'custom-make-node custom-tree))
 

--- a/treepy.el
+++ b/treepy.el
@@ -1,43 +1,34 @@
-;;; treepy.el --- Generic tree traversal tools           -*- lexical-binding: t -*-
-;;
-;; Filename: treepy.el
-;; 
+;;; treepy.el --- Generic tree traversal tools  -*- lexical-binding: t -*-
+
 ;; Copyright (C) 2017 Daniel Barreto
-;;
-;; Description: Generic Tree Traversing Tools
+
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Keywords: lisp, maint, tools
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
 ;; Version: 0.1.1
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
-;;; Commentary:
-;; 
-;; Generic tools for recursive and iterative tree traversal based on
-;; clojure.walk and clojure.zip respectively.  Depends on `map', a map
-;; manipulation library built in Emacs 25.1.  All functions are prefixed
-;; with "treepy-"
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or (at
 ;; your option) any later version.
-;; 
+;;
 ;; This program is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;; 
+;;
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
-;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 
+
+;;; Commentary:
+
+;; Generic tools for recursive and iterative tree traversal based on
+;; clojure.walk and clojure.zip respectively.  Depends on `map', a map
+;; manipulation library built in Emacs 25.1.  All functions are prefixed
+;; with "treepy-".
+
 ;;; Code:
 
 (require 'map)

--- a/treepy.el
+++ b/treepy.el
@@ -157,9 +157,9 @@ Execute BODY in this context."
   (declare (indent defun))
   (let ((lex-ctx (mapcar (lambda (v)
                            (cl-case v
-                             ('node    `(node (treepy-node ,loc)))
-                             ('context `(context (treepy--context ,loc)))
-                             (t        `(,v (treepy--context ,loc (quote ,(intern (concat ":" (symbol-name v)))))))))
+                             (node    `(node (treepy-node ,loc)))
+                             (context `(context (treepy--context ,loc)))
+                             (t       `(,v (treepy--context ,loc (quote ,(intern (concat ":" (symbol-name v)))))))))
                          vars)))
     `(let* (,@lex-ctx) ,@body)))
 
@@ -440,8 +440,8 @@ When reaching the end, returns a distinguished loc detectable via
 Use ORDER if given.  Possible values for ORDER are `:preorder' and
 `:postorder', defaults to the former."
   (cl-case (or order ':preorder)
-    (':preorder (treepy--preorder-next loc))
-    (':postorder (treepy--postorder-next loc))
+    (:preorder (treepy--preorder-next loc))
+    (:postorder (treepy--postorder-next loc))
     (t (error "Unrecognized order"))))
 
 (defun treepy--preorder-prev (loc)
@@ -471,8 +471,8 @@ If already at the root, returns nil."
 Use ORDER if given.  Possible values for ORDER are `:preorder' and `:postorder',
 defaults to the former."
   (cl-case (or order ':preorder)
-    (':preorder (treepy--preorder-prev loc))
-    (':postorder (treepy--postorder-prev loc))
+    (:preorder (treepy--preorder-prev loc))
+    (:postorder (treepy--postorder-prev loc))
     (t (error "Unrecognized order"))))
 
 (defun treepy-end-p (loc)


### PR DESCRIPTION
Unlike for `pcase` keys do not have to be quoted for `cl-case' and
doing so actually changes what is being matched, or as Emacs-29's
byte-compiler puts it:

```
  Warning: Case ':preorder will match ‘quote’.  If that’s intended,
  write (:preorder quote) instead.  Otherwise, don’t quote
  ‘:preorder’.
```

Some cleanup also slipped in, in separate commits.