### PR TITLE
Deprecate use of map-contains-key's problematic TESTFN argument

### DIFF
--- a/treepy.el
+++ b/treepy.el
@@ -80,18 +80,28 @@ Return a list of each form as it is walked."
 
 (defun treepy-postwalk-replace (smap form &optional testfn)
   "Use SMAP to transform FORM by doing replacing operations.
-Recursively replace in FORM keys in SMAP with their values.  Does
-replacement at the leaves of the tree first.  The optional TESTFN
-parameter is the function to be used by `map-contains-key'."
-  (treepy-postwalk (lambda (x) (if (map-contains-key smap x testfn) (map-elt smap x) x))
+Recursively replace in FORM keys in SMAP with their values.
+Does replacement at the leaves of the tree first."
+  ;; Also see comment in `map-contains-key's definition.
+  (declare (advertised-calling-convention (smap key) "0.1.3"))
+  (treepy-postwalk (lambda (x)
+                     (if (with-suppressed-warnings ((callargs map-contains-key))
+                           (map-contains-key smap x testfn))
+                         (map-elt smap x)
+                       x))
                    form))
 
 (defun treepy-prewalk-replace (smap form &optional testfn)
   "Use SMAP to transform FORM by doing replacing operations.
-Recursively replace in FORM keys in SMAP with their values.  Does
-replacement at the root of the tree first.  The optional TESTFN
-parameter is the function to be used by `map-contains-key'."
-  (treepy-prewalk (lambda (x) (if (map-contains-key smap x testfn) (map-elt smap x) x))
+Recursively replace in FORM keys in SMAP with their values.
+Does replacement at the root of the tree first."
+  ;; Also see comment in `map-contains-key's definition.
+  (declare (advertised-calling-convention (smap key) "0.1.3"))
+  (treepy-prewalk (lambda (x)
+                    (if (with-suppressed-warnings ((callargs map-contains-key))
+                          (map-contains-key smap x testfn))
+                        (map-elt smap x)
+                      x))
                   form))
 
 


### PR DESCRIPTION
The argument wasn't actually deprecated until Emacs 29.1, but
the definition contained this comment ever since Emacs 27.1:

``` emacs-lisp
;; FIXME: The test function to use generally depends on the map object,
;; so specifying `testfn' here is problematic: e.g. for hash-tables
;; we shouldn't use `gethash' unless `testfn' is the same as the map's own
;; test function!
```