### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/test/treepy.el-walker-test.el
+++ b/test/treepy.el-walker-test.el
@@ -2,7 +2,7 @@
 
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
 

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -2,7 +2,7 @@
 
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Package-Requires: ((emacs "25"))
 ;; URL: https://github.com/volrath/treepy.el
 

--- a/treepy.el
+++ b/treepy.el
@@ -5,7 +5,7 @@
 ;; Author: Daniel Barreto <daniel.barreto.n@gmail.com>
 ;; Keywords: lisp, maint, tools
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/volrath/treepy.el
 


### PR DESCRIPTION
Hi @volrath!

Will you bump the version to 0.1.2 (from 0.1.1)?

You have already tagged a commit with version 0.1.2, and @tarsius has bumped the version to 0.1.2 in this reference: https://github.com/magit/ghub/commit/05753f872a7450bff7b0f83aec9e26eee9d9f84c.

Please correct if I didn't do it correctly.  Thanks!