### PR TITLE
fix: treepy-leftmost, treepy-rightmost

### DIFF
--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -124,8 +124,44 @@
            (:r . nil)))
     (-> lz
         treepy-next)
-    '((a b . c) . :end)))
+    '((a b . c) . :end))
 
+  (assert-traversing-with-persistent-zipper [lz (treepy-list-zip '(1 2 3 4 5 6 7))]
+    (-> lz
+        treepy-down
+        treepy-rightmost)
+    '(7
+      (:l 6 5 4 3 2 1)
+      (:pnodes (1 2 3 4 5 6 7))
+      (:ppath)
+      (:r))
+    (-> lz
+        treepy-leftmost)
+    '(1
+      (:l)
+      (:pnodes (1 2 3 4 5 6 7))
+      (:ppath)
+      (:r 2 3 4 5 6 7))
+    (-> lz
+        treepy-right
+        treepy-right
+        treepy-right
+        treepy-rightmost)
+    '(7
+      (:l 6 5 4 3 2 1)
+      (:pnodes (1 2 3 4 5 6 7))
+      (:ppath)
+      (:r))
+    (-> lz
+        treepy-left
+        treepy-left
+        treepy-left
+        treepy-leftmost)
+    '(1
+      (:l)
+      (:pnodes (1 2 3 4 5 6 7))
+      (:ppath)
+      (:r 2 3 4 5 6 7))))
 
 ;;; Vector Zipper
 

--- a/treepy.el
+++ b/treepy.el
@@ -302,7 +302,7 @@ If LOC is already the rightmost sibling, return self."
         (treepy--with-meta
          (cons (car (last r))
                (treepy--context-assoc context
-                 :l (treepy--join-children l (cons node (butlast r)))
+                 :l (reverse (treepy--join-children l (cons node (butlast r))))
                  :r nil))
          (treepy--meta loc))
       loc)))
@@ -328,7 +328,7 @@ If LOC is already the leftmost sibling, return self."
         (treepy--with-meta
          (cons (car (last l))
                (treepy--context-assoc context
-                 :l []
+                 :l nil
                  :r (treepy--join-children (butlast l) (cons node r))))
          (treepy--meta loc))
       loc)))


### PR DESCRIPTION
# The Issue

Functions `treepy-leftmost` and `treepy-rightmost` doesn't represent left and right hand side like `treepy-left` or `treely-right` does.
This affects reconstruction of data whenever it's changed.
Most affected is `treepy-rightmost` as it reverses whole lhs when going back to root.

## Example

```lisp
(let ((data (treepy-list-zip (list 1 2 (list 3 4)))))
  (treepy-root (treepy-append-child (treepy-rightmost (treepy-down data)) 5)))
;; return (2 1 (3 4 5))
;; expected (1 2 (3 4 5))
```

# What's Changed

Provided patch brings behavior of these function closer to their less specialized counterparts and adds lacking test coverage for them.