### PR TITLE
Silence test byte-compile warnings; add CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Minimum supported (Package-Requires) + latest stable + snapshot.
+        emacs_version:
+          - '27.1'
+          - '30.1'
+          - snapshot
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Byte-compile (warnings as errors)
+        run: |
+          emacs -Q --batch -L . -L test \
+            --eval '(setq byte-compile-error-on-warn t)' \
+            -f batch-byte-compile \
+            treepy.el \
+            test/treepy.el-zipper-test.el \
+            test/treepy.el-walker-test.el
+
+      - name: Run tests
+        run: |
+          emacs -Q --batch -L . -L test \
+            -l test/treepy.el-zipper-test.el \
+            -l test/treepy.el-walker-test.el \
+            -f ert-run-tests-batch-and-exit

--- a/test/treepy.el-zipper-test.el
+++ b/test/treepy.el-zipper-test.el
@@ -260,7 +260,7 @@
 
 ;;; Preorder vs Postorder
 
-(setq numered-tree '(1 . ((2 . (4 5)) 3)))
+(defvar numered-tree '(1 . ((2 . (4 5)) 3)))
 
 (defun numered-children (node)
   (cdr node))
@@ -368,7 +368,7 @@ be (defn new-&node-type> [field-map])."
                (:concat `((:args . ,children)))
                (:value `((:val . ,(car children))))))))
 
-(setq custom-zipper (treepy-zipper #'custom-branch-p #'custom-children #'custom-make-node custom-tree))
+(defvar custom-zipper (treepy-zipper #'custom-branch-p #'custom-children #'custom-make-node custom-tree))
 
 (defun can-simplify-concat? (node)
   (and (equal ':concat (node-type node))
@@ -470,7 +470,7 @@ be (defn new-&node-type> [field-map])."
 
 
 (defun treepy-parseclj--make-node (node children)
-  "Helper parseclj function to create nodes 'a la treepy'.
+  "Helper parseclj function to create nodes a la treepy.
 NODE is an AST node.  CHILDREN is a list of AST nodes."
   (mapcar (lambda (pair)
             (if (eql (car pair) :children)

--- a/treepy.el
+++ b/treepy.el
@@ -6,7 +6,7 @@
 ;; Keywords: lisp, maint, tools
 ;; Created: Mon Jul 10 15:17:36 2017 (+0200)
 ;; Version: 0.1.3
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; URL: https://github.com/volrath/treepy.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## What

Clear the byte-compile warnings in `test/treepy.el-zipper-test.el` and
add CI so they do not come back.

## Changes

**Fix (commit 1).**
- `numered-tree` and `custom-zipper` are assigned at top level with
  `setq`, which the byte-compiler flags as assignment/reference to free
  variables; declare them with `defvar`.
- Fix a docstring that used unescaped single quotes around "a la
  treepy".

**CI (commit 2).** Add a GitHub Actions workflow that byte-compiles
(warnings as errors) and runs the test suite on the minimum supported
Emacs, the latest stable (30.1), and the development snapshot, plus
dependabot for the actions.

This also corrects `Package-Requires` from 25.1 to 27.1: `treepy.el`
uses `with-suppressed-warnings` (added in Emacs 27.1), so it does not
byte-compile on 25.1.

## Verification

All CI jobs pass: https://github.com/dannywillems/treepy.el/actions